### PR TITLE
ReviewerGossipForm::execute - remove undefined value

### DIFF
--- a/controllers/grid/users/reviewer/form/ReviewerGossipForm.inc.php
+++ b/controllers/grid/users/reviewer/form/ReviewerGossipForm.inc.php
@@ -67,7 +67,6 @@ class ReviewerGossipForm extends Form {
 		$userDao = DAORegistry::getDAO('UserDAO'); /* @var $userDao UserDAO */
 		$userDao->updateObject($this->_user);
 		parent::execute(...$functionArgs);
-		return $user;
 	}
 }
 


### PR DESCRIPTION
ReviewerGossipForm::execute was returning an undefined value eliciting a PHP Notice. @asmecher advised this is not used or documented. Therefore, I propose it can be removed. Discussion: https://forum.pkp.sfu.ca/t/ojs-3-2-1-missing-variable-when-setting-reviewer-notes/61888. [JP]